### PR TITLE
extend cluster info

### DIFF
--- a/pkg/apiserver/cubeapi/cluster/handler.go
+++ b/pkg/apiserver/cubeapi/cluster/handler.go
@@ -69,16 +69,18 @@ type result struct {
 }
 
 type clusterInfo struct {
-	ClusterName         string    `json:"clusterName"`
-	ClusterDescription  string    `json:"clusterDescription"`
-	NetworkType         string    `json:"networkType"`
-	HarborAddr          string    `json:"harborAddr"`
-	IsMemberCluster     bool      `json:"isMemberCluster"`
-	IsWritable          bool      `json:"isWritable"`
-	CreateTime          time.Time `json:"createTime"`
-	KubeApiServer       string    `json:"kubeApiServer"`
-	Status              string    `json:"status"`
-	IngressDomainSuffix string    `json:"ingressDomainSuffix,omitempty"`
+	ClusterName         string            `json:"clusterName"`
+	ClusterDescription  string            `json:"clusterDescription"`
+	NetworkType         string            `json:"networkType"`
+	HarborAddr          string            `json:"harborAddr"`
+	IsMemberCluster     bool              `json:"isMemberCluster"`
+	IsWritable          bool              `json:"isWritable"`
+	CreateTime          time.Time         `json:"createTime"`
+	KubeApiServer       string            `json:"kubeApiServer"`
+	Status              string            `json:"status"`
+	IngressDomainSuffix string            `json:"ingressDomainSuffix,omitempty"`
+	Labels              map[string]string `json:"labels,omitempty"`
+	Annotations         map[string]string `json:"annotations,omitempty"`
 
 	// todo(weilaaa): move to monitor info
 	NodeCount             int `json:"nodeCount"`

--- a/pkg/apiserver/cubeapi/cluster/helper.go
+++ b/pkg/apiserver/cubeapi/cluster/helper.go
@@ -73,6 +73,8 @@ func makeClusterInfos(ctx context.Context, clusters clusterv1.ClusterList, pivot
 		info.KubeApiServer = cluster.Spec.KubernetesAPIEndpoint
 		info.NetworkType = cluster.Spec.NetworkType
 		info.IngressDomainSuffix = cluster.Spec.IngressDomainSuffix
+		info.Labels = cluster.Labels
+		info.Annotations = cluster.Annotations
 
 		internalCluster, err := multicluster.Interface().Get(v)
 		if internalCluster != nil && err != nil {


### PR DESCRIPTION
Ⅰ. Describe what this PR does
Currently, the cluster information interface only returns some of the cluster fields. Considering that some of the extended information will be placed in Label and annotation, these two contents will be returned