### PR TITLE
fix bug when query pod

### DIFF
--- a/pkg/apiserver/cubeapi/resourcemanage/resources/pod/pod.go
+++ b/pkg/apiserver/cubeapi/resourcemanage/resources/pod/pod.go
@@ -61,7 +61,7 @@ func Handle(param resourcemanage.ExtendParams) (interface{}, error) {
 		return nil, errors.New(errcode.ClusterNotFoundError(param.Cluster).Message)
 	}
 	pod := NewPod(kubernetes, param.Namespace, param.Filter)
-	if pod.filter.EnableFilter {
+	if pod.filter.EnableFilter && pod.filter.Exact[ownerUidLabel].Len() > 0 {
 		err := pod.GetRs()
 		if err != nil {
 			return nil, errors.New(err.Error())


### PR DESCRIPTION
Ⅰ. Describe what this PR does
When querying a pod, we only need to query the information corresponding to the replacementset when filtering according to the ownerReferences.uid of the pod, and no need for other cases