### PR TITLE
Feature cube k8s proxy

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -19,6 +19,7 @@ package apiserver
 import (
 	"context"
 	"fmt"
+	"github.com/kubecube-io/kubecube/pkg/apiserver/cubeapi/k8s"
 	"net/http"
 	"time"
 
@@ -161,6 +162,7 @@ func apisOutsideMiddlewares(root *gin.Engine) {
 	scout.AddApisTo(root)
 
 	root.GET(constants.ApiPathRoot+"/extend/configmap/:configmap", resourcemanage.GetConfigMap)
+	root.Any(constants.ApiK8sProxyPath+"/*path", k8s.NewHandler().LocalClusterProxy)
 }
 
 func (s *APIServer) Initialize() error {

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -19,7 +19,6 @@ package apiserver
 import (
 	"context"
 	"fmt"
-	"github.com/kubecube-io/kubecube/pkg/apiserver/cubeapi/k8s"
 	"net/http"
 	"time"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/kubecube-io/kubecube/pkg/apiserver/cubeapi/authorization"
 	"github.com/kubecube-io/kubecube/pkg/apiserver/cubeapi/cluster"
 	"github.com/kubecube-io/kubecube/pkg/apiserver/cubeapi/healthz"
+	"github.com/kubecube-io/kubecube/pkg/apiserver/cubeapi/k8s"
 	"github.com/kubecube-io/kubecube/pkg/apiserver/cubeapi/key"
 	resourcemanage "github.com/kubecube-io/kubecube/pkg/apiserver/cubeapi/resourcemanage/handle"
 	"github.com/kubecube-io/kubecube/pkg/apiserver/cubeapi/scout"

--- a/pkg/apiserver/cubeapi/k8s/proxy.go
+++ b/pkg/apiserver/cubeapi/k8s/proxy.go
@@ -1,0 +1,33 @@
+package k8s
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/kubecube-io/kubecube/pkg/clog"
+	"github.com/kubecube-io/kubecube/pkg/multicluster"
+	"github.com/kubecube-io/kubecube/pkg/utils/constants"
+	"github.com/kubecube-io/kubecube/pkg/warden/server/authproxy"
+)
+
+type Handler struct {
+	*authproxy.Handler
+}
+
+func NewHandler() *Handler {
+	h := new(Handler)
+	cluster, err := multicluster.Interface().Get(constants.LocalCluster)
+	if err != nil {
+		clog.Fatal("get local cluster failed: %v", err)
+	}
+	authProxyHandler, err := authproxy.GetHandlerByConfig(cluster.Config)
+	if err != nil {
+		clog.Fatal("get local cluster auth proxy handler failed: %v", err)
+	}
+	h.Handler = authProxyHandler
+	return h
+}
+
+func (h *Handler) LocalClusterProxy(c *gin.Context) {
+	path := c.Param("path")
+	c.Request.URL.Path = path
+	h.ServeHTTP(c.Writer, c.Request)
+}

--- a/pkg/apiserver/cubeapi/k8s/proxy.go
+++ b/pkg/apiserver/cubeapi/k8s/proxy.go
@@ -18,7 +18,10 @@ func NewHandler() *Handler {
 	if err != nil {
 		clog.Fatal("get local cluster failed: %v", err)
 	}
-	authProxyHandler, err := authproxy.GetHandlerByConfig(cluster.Config)
+	authProxyHandler := &authproxy.Handler{}
+	authProxyHandler.SetHandlerClient(cluster.Client)
+	err = authProxyHandler.SetHandlerTS(cluster.Config)
+
 	if err != nil {
 		clog.Fatal("get local cluster auth proxy handler failed: %v", err)
 	}

--- a/pkg/apiserver/cubeapi/k8s/proxy.go
+++ b/pkg/apiserver/cubeapi/k8s/proxy.go
@@ -18,6 +18,7 @@ package k8s
 
 import (
 	"github.com/gin-gonic/gin"
+
 	"github.com/kubecube-io/kubecube/pkg/clog"
 	"github.com/kubecube-io/kubecube/pkg/multicluster"
 	"github.com/kubecube-io/kubecube/pkg/utils/constants"

--- a/pkg/apiserver/cubeapi/k8s/proxy.go
+++ b/pkg/apiserver/cubeapi/k8s/proxy.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 KubeCube Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package k8s
 
 import (

--- a/pkg/conversion/conversion.go
+++ b/pkg/conversion/conversion.go
@@ -173,7 +173,7 @@ func (c *VersionConverter) GvkGreeting(gvk *schema.GroupVersionKind) (greetBack 
 	// todo: cache the result of all resources
 	_, allResources, err := c.discovery.ServerGroupsAndResources()
 	if err != nil {
-		return IsUnknown, gvk, nil, err
+		clog.Warn("some api group is not available in target cluster, err: %s", err.Error())
 	}
 	if allResources != nil {
 		for _, gvs := range allResources {

--- a/pkg/multicluster/client/client.go
+++ b/pkg/multicluster/client/client.go
@@ -143,7 +143,7 @@ func NewClientFor(ctx context.Context, cfg *rest.Config) (Client, error) {
 	if !config.ClusterCacheSyncEnable {
 		return c, nil
 	}
-	// add a timed task, call RefreshCacheDiscovery method every hour, refresh the cache
+	// add a timed task, call RefreshCacheDiscovery method , refresh the cache
 	tick := time.NewTimer(time.Second * time.Duration(config.ClusterCacheSyncInterval))
 	go func() {
 		for {

--- a/pkg/multicluster/client/client.go
+++ b/pkg/multicluster/client/client.go
@@ -19,7 +19,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"github.com/kubecube-io/kubecube/pkg/utils/env"
 	"time"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -39,6 +38,7 @@ import (
 
 	"github.com/kubecube-io/kubecube/pkg/apis"
 	"github.com/kubecube-io/kubecube/pkg/clog"
+	"github.com/kubecube-io/kubecube/pkg/utils/env"
 )
 
 var (

--- a/pkg/multicluster/client/config/config.go
+++ b/pkg/multicluster/client/config/config.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 KubeCube Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package config
 
 type Config struct {

--- a/pkg/multicluster/client/config/config.go
+++ b/pkg/multicluster/client/config/config.go
@@ -1,0 +1,20 @@
+package config
+
+type Config struct {
+	// QPS indicates the maximum QPS to the master from this client.
+	// If it's zero, the created RESTClient will use DefaultQPS: 5
+	QPS float32 `json:"qps,omitempty"`
+
+	// Maximum burst for throttle.
+	// If it's zero, the created RESTClient will use DefaultBurst: 10.
+	Burst int `json:"burst,omitempty"`
+
+	// The maximum length of time to wait before giving up on a server request. A value of zero means no timeout, Default: 0.
+	TimeoutSecond int `json:"timeoutSecond,omitempty"`
+
+	// the cluster discovery cache sync enable, default is false
+	ClusterCacheSyncEnable bool `json:"clusterCacheSyncEnable,omitempty"`
+
+	// the cluster discovery cache sync interval，unit is second, default is 60
+	ClusterCacheSyncInterval int `json:"clusterCacheSyncInterval,omitempty"`
+}

--- a/pkg/utils/constants/constants.go
+++ b/pkg/utils/constants/constants.go
@@ -26,6 +26,8 @@ const (
 	// ApiPathRoot the root api route
 	ApiPathRoot = "/api/v1/cube"
 
+	ApiK8sProxyPath = "/api/v1/cube/kubernetes"
+
 	// LocalCluster the internal cluster where program stand with
 	LocalCluster = "_local_cluster"
 

--- a/pkg/utils/env/env.go
+++ b/pkg/utils/env/env.go
@@ -195,12 +195,12 @@ func GetClusterClientConfig() config.Config {
 		qpsFloat32 = float32(qpsFloat)
 	}
 	burst := os.Getenv("CLUSTER_CLIENT_BURST")
-	burstInt, err := strconv.ParseInt(burst, 10, 64)
+	burstInt, err := strconv.Atoi(burst)
 	if err != nil {
 		burstInt = 10
 	}
 	timeout := os.Getenv("CLUSTER_CLIENT_TIMEOUT_SECONDS")
-	timeoutInt, err := strconv.ParseInt(timeout, 10, 64)
+	timeoutInt, err := strconv.Atoi(timeout)
 	if err != nil {
 		timeoutInt = 0
 	}
@@ -210,15 +210,15 @@ func GetClusterClientConfig() config.Config {
 		clusterCacheSyncEnableBool = false
 	}
 	clusterCacheSyncInterval := os.Getenv("DISCOVERY_CACHE_SYNC_PERIOD")
-	clusterCacheSyncIntervalInt, err := strconv.ParseInt(clusterCacheSyncInterval, 10, 64)
+	clusterCacheSyncIntervalInt, err := strconv.Atoi(clusterCacheSyncInterval)
 	if err != nil {
 		clusterCacheSyncIntervalInt = 60
 	}
 	return config.Config{
 		QPS:                      qpsFloat32,
-		Burst:                    int(burstInt),
-		TimeoutSecond:            int(timeoutInt),
+		Burst:                    burstInt,
+		TimeoutSecond:            timeoutInt,
 		ClusterCacheSyncEnable:   clusterCacheSyncEnableBool,
-		ClusterCacheSyncInterval: int(clusterCacheSyncIntervalInt),
+		ClusterCacheSyncInterval: clusterCacheSyncIntervalInt,
 	}
 }

--- a/pkg/utils/env/env.go
+++ b/pkg/utils/env/env.go
@@ -17,14 +17,15 @@ limitations under the License.
 package env
 
 import (
-	"github.com/kubecube-io/kubecube/pkg/clog"
-	"github.com/kubecube-io/kubecube/pkg/multicluster/client/config"
-	"github.com/kubecube-io/kubecube/pkg/utils/constants"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/kubecube-io/kubecube/pkg/clog"
+	"github.com/kubecube-io/kubecube/pkg/multicluster/client/config"
+	"github.com/kubecube-io/kubecube/pkg/utils/constants"
 )
 
 type AuditSvcApi struct {

--- a/pkg/utils/env/env.go
+++ b/pkg/utils/env/env.go
@@ -17,13 +17,14 @@ limitations under the License.
 package env
 
 import (
+	"github.com/kubecube-io/kubecube/pkg/clog"
+	"github.com/kubecube-io/kubecube/pkg/multicluster/client/config"
+	"github.com/kubecube-io/kubecube/pkg/utils/constants"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
-
-	"github.com/kubecube-io/kubecube/pkg/clog"
-	"github.com/kubecube-io/kubecube/pkg/utils/constants"
 )
 
 type AuditSvcApi struct {
@@ -182,4 +183,42 @@ func hncManagedLabels() map[string]string {
 		labels[res[0]] = res[1]
 	}
 	return labels
+}
+
+func GetClusterClientConfig() config.Config {
+	qps := os.Getenv("CLUSTER_CLIENT_QPS")
+	qpsFloat, err := strconv.ParseFloat(qps, 32)
+	var qpsFloat32 float32
+	if err != nil {
+		qpsFloat32 = float32(5)
+	} else {
+		qpsFloat32 = float32(qpsFloat)
+	}
+	burst := os.Getenv("CLUSTER_CLIENT_BURST")
+	burstInt, err := strconv.ParseInt(burst, 10, 64)
+	if err != nil {
+		burstInt = 10
+	}
+	timeout := os.Getenv("CLUSTER_CLIENT_TIMEOUT_SECONDS")
+	timeoutInt, err := strconv.ParseInt(timeout, 10, 64)
+	if err != nil {
+		timeoutInt = 0
+	}
+	clusterCacheSyncEnable := os.Getenv("DISCOVERY_CACHE_SYNC_ENABLE")
+	clusterCacheSyncEnableBool, err := strconv.ParseBool(clusterCacheSyncEnable)
+	if err != nil {
+		clusterCacheSyncEnableBool = false
+	}
+	clusterCacheSyncInterval := os.Getenv("DISCOVERY_CACHE_SYNC_PERIOD")
+	clusterCacheSyncIntervalInt, err := strconv.ParseInt(clusterCacheSyncInterval, 10, 64)
+	if err != nil {
+		clusterCacheSyncIntervalInt = 60
+	}
+	return config.Config{
+		QPS:                      qpsFloat32,
+		Burst:                    int(burstInt),
+		TimeoutSecond:            int(timeoutInt),
+		ClusterCacheSyncEnable:   clusterCacheSyncEnableBool,
+		ClusterCacheSyncInterval: int(clusterCacheSyncIntervalInt),
+	}
 }

--- a/pkg/warden/server/authproxy/authproxy.go
+++ b/pkg/warden/server/authproxy/authproxy.go
@@ -54,14 +54,17 @@ type Handler struct {
 }
 
 func NewHandler(localClusterKubeConfig string) (*Handler, error) {
-	h := &Handler{}
-	h.authMgr = jwt.GetAuthJwtImpl()
-
 	// get cluster info from rest config
 	restConfig, err := clientcmd.BuildConfigFromFlags("", localClusterKubeConfig)
 	if err != nil {
 		return nil, err
 	}
+	return GetHandlerByConfig(restConfig)
+}
+
+func GetHandlerByConfig(restConfig *rest.Config) (*Handler, error) {
+	h := &Handler{}
+	h.authMgr = jwt.GetAuthJwtImpl()
 
 	cli, err := client.NewClientFor(context.Background(), restConfig)
 	if err != nil {
@@ -124,6 +127,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// impersonate given user to access k8s-apiserver
 	r.Header.Set(constants.ImpersonateUserKey, userInfo.Username)
-
+	r.Header.Del(constants.AuthorizationHeader)
 	h.proxy.ServeHTTP(w, r)
 }

--- a/pkg/warden/warden.go
+++ b/pkg/warden/warden.go
@@ -18,16 +18,16 @@ package warden
 
 import (
 	"context"
-	"github.com/kubecube-io/kubecube/pkg/authentication/authenticators/jwt"
-	"github.com/kubecube-io/kubecube/pkg/utils/constants"
-	"k8s.io/api/authentication/v1beta1"
-	restclient "k8s.io/client-go/rest"
 	"strings"
 
+	"k8s.io/api/authentication/v1beta1"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/kubecube-io/kubecube/pkg/authentication/authenticators/jwt"
 	"github.com/kubecube-io/kubecube/pkg/clog"
 	multiclient "github.com/kubecube-io/kubecube/pkg/multicluster/client"
+	"github.com/kubecube-io/kubecube/pkg/utils/constants"
 	"github.com/kubecube-io/kubecube/pkg/warden/localmgr"
 	"github.com/kubecube-io/kubecube/pkg/warden/reporter"
 	"github.com/kubecube-io/kubecube/pkg/warden/server"

--- a/pkg/warden/warden.go
+++ b/pkg/warden/warden.go
@@ -143,7 +143,7 @@ func (w *Warden) Run(stop <-chan struct{}) {
 
 // makePivotClient make client for pivot client
 func makePivotClient(opts *Config) (multiclient.Client, error) {
-	cfg := &restclient.Config{}
+	var cfg *restclient.Config
 	var err error
 	if len(opts.PivotClusterKubeConfig) != 0 {
 		cfg, err = clientcmd.BuildConfigFromFlags("", opts.PivotClusterKubeConfig)

--- a/pkg/warden/warden.go
+++ b/pkg/warden/warden.go
@@ -18,6 +18,11 @@ package warden
 
 import (
 	"context"
+	"github.com/kubecube-io/kubecube/pkg/authentication/authenticators/jwt"
+	"github.com/kubecube-io/kubecube/pkg/utils/constants"
+	"k8s.io/api/authentication/v1beta1"
+	restclient "k8s.io/client-go/rest"
+	"strings"
 
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -43,7 +48,7 @@ type Warden struct {
 }
 
 func NewWardenWithOpts(opts *Config) *Warden {
-	pivotClient, err := makePivotClient(opts.PivotClusterKubeConfig)
+	pivotClient, err := makePivotClient(opts)
 	if err != nil {
 		clog.Fatal("init pivot client failed: %v", err)
 	}
@@ -137,16 +142,43 @@ func (w *Warden) Run(stop <-chan struct{}) {
 }
 
 // makePivotClient make client for pivot client
-func makePivotClient(kubeconfig string) (multiclient.Client, error) {
-	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
-	if err != nil {
-		return nil, err
+func makePivotClient(opts *Config) (multiclient.Client, error) {
+	cfg := &restclient.Config{}
+	var err error
+	if len(opts.PivotClusterKubeConfig) != 0 {
+		cfg, err = clientcmd.BuildConfigFromFlags("", opts.PivotClusterKubeConfig)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		authJwtImpl := jwt.GetAuthJwtImpl()
+		token, errInfo := authJwtImpl.GenerateTokenWithExpired(&v1beta1.UserInfo{Username: "admin"}, 100*365*24*3600)
+		if errInfo != nil {
+			return nil, err
+		}
+
+		host := opts.PivotCubeHost
+		if !strings.HasPrefix(host, "http://") && !strings.HasPrefix(host, "https://") {
+			// default, use https as scheme
+			host = "https://" + host
+		}
+		if strings.HasSuffix(host, "/") {
+			host = strings.TrimSuffix(host, "/")
+		}
+		host += constants.ApiK8sProxyPath
+
+		cfg = &restclient.Config{
+			Host:        host,
+			BearerToken: token,
+			TLSClientConfig: restclient.TLSClientConfig{
+				Insecure: true,
+			},
+		}
 	}
 
 	cli, err := multiclient.NewClientFor(context.Background(), cfg)
 	if err != nil {
 		return nil, err
 	}
-
 	return cli, nil
 }


### PR DESCRIPTION
Ⅰ. Describe what this PR does
In the kubecube service, add the ability to proxy the current cluster k8s; in this way, warden does not need to connect to the apiserver that controls the cluster, but only needs to connect to kubecube to achieve the existing capabilities.